### PR TITLE
Update DailyToDoController

### DIFF
--- a/src/main/java/beom/plantoplantserver/controller/DailyToDoController.java
+++ b/src/main/java/beom/plantoplantserver/controller/DailyToDoController.java
@@ -2,7 +2,6 @@ package beom.plantoplantserver.controller;
 
 import beom.plantoplantserver.model.dto.request.CalendarRequest;
 import beom.plantoplantserver.model.dto.response.UserCalendarResponse;
-import beom.plantoplantserver.model.entity.Calendar;
 import beom.plantoplantserver.service.DailyToDoService;
 import org.springframework.web.bind.annotation.*;
 
@@ -17,13 +16,8 @@ public class DailyToDoController {
         this.dailyToDoService = dailyToDoService;
     }
 
-    @GetMapping("/today")
-    public List<UserCalendarResponse> getToDoForToday(@RequestParam("user_id") String user_id){
-        return dailyToDoService.getToDoForToday(user_id);
-    }
-
-    @PostMapping("/optional-dates")
-    public List<UserCalendarResponse> getToDoForDate(@RequestBody CalendarRequest request){
-        return dailyToDoService.getToDoForDate(request);
+    @GetMapping("/all")
+    public List<UserCalendarResponse> getToDoAll(@RequestParam("user_id") String user_id){
+        return dailyToDoService.getAllToDo(user_id);
     }
 }

--- a/src/main/java/beom/plantoplantserver/repository/CalendarRepo.java
+++ b/src/main/java/beom/plantoplantserver/repository/CalendarRepo.java
@@ -11,6 +11,6 @@ public interface CalendarRepo extends JpaRepository<Calendar, Integer> {
 
     List<UserCalendarResponse> findByUserIdAndDateBetweenAndToDoVisibilityCalendarIsTrue(String user_id
             , LocalDate start, LocalDate end);
-    List<UserCalendarResponse> findByUserIdAndDate(String user_id, LocalDate date);
     List<Calendar> findByDateAndToDoCompletedIsTrue(LocalDate date);
+    List<UserCalendarResponse> findByUserId(String user_id);
 }

--- a/src/main/java/beom/plantoplantserver/service/DailyToDoService.java
+++ b/src/main/java/beom/plantoplantserver/service/DailyToDoService.java
@@ -2,11 +2,9 @@ package beom.plantoplantserver.service;
 
 import beom.plantoplantserver.model.dto.request.CalendarRequest;
 import beom.plantoplantserver.model.dto.response.UserCalendarResponse;
-import beom.plantoplantserver.model.entity.Calendar;
 
 import java.util.List;
 
 public interface DailyToDoService {
-    List<UserCalendarResponse> getToDoForToday(String user_id);
-    List<UserCalendarResponse> getToDoForDate(CalendarRequest request);
+    List<UserCalendarResponse> getAllToDo(String user_id);
 }

--- a/src/main/java/beom/plantoplantserver/service/DailyToDoServiceImpl.java
+++ b/src/main/java/beom/plantoplantserver/service/DailyToDoServiceImpl.java
@@ -18,31 +18,17 @@ public class DailyToDoServiceImpl implements DailyToDoService{
     private final CalendarRepo calendarRepo;
 
     @Override
-    public List<UserCalendarResponse> getToDoForToday(String user_id) {
-        LocalDate now = LocalDate.now();
-
-        return getUserDailyToDo(user_id, now);
-    }
-
-    @Override
-    public List<UserCalendarResponse> getToDoForDate(CalendarRequest request) {
-        LocalDate date = LocalDate.of(request.getYear(), request.getMonth(), request.getDay());
-        String uId = request.getUser_id();
-
-        return getUserDailyToDo(uId, date);
-    }
-
-    private List<UserCalendarResponse> getUserDailyToDo(String user_id, LocalDate now){
-        List<UserCalendarResponse> userCalendarResponses = calendarRepo.findByUserIdAndDate(user_id, now);
-        List<UserCalendarResponse> resUserDailyResponses = new ArrayList<>();
-        for(UserCalendarResponse c : userCalendarResponses){
-            resUserDailyResponses.add(UserCalendarResponse.builder()
-                    .id(c.getId())
-                    .date(c.getDate())
-                    .toDo(c.getToDo())
-                    .toDoCompleted(c.getToDoCompleted())
+    public List<UserCalendarResponse> getAllToDo(String user_id) {
+        List<UserCalendarResponse> userCalendarResponses = calendarRepo.findByUserId(user_id);
+        List<UserCalendarResponse> res = new ArrayList<>();
+        for (UserCalendarResponse u : userCalendarResponses){
+            res.add(UserCalendarResponse.builder()
+                    .id(u.getId())
+                    .date(u.getDate())
+                    .toDo(u.getToDo())
+                    .toDoCompleted(u.getToDoCompleted())
                     .build());
         }
-        return resUserDailyResponses;
+        return res;
     }
 }


### PR DESCRIPTION
### 오늘의 할 일 목록을 가져오는 메서드와 지정 날짜의 할 일 목록을 가져오는 메서드를 삭제했습니다.
: 이유는 다음과 같습니다.
  - 만드려는 어플리케이션에 지정된 날짜의 데이터를 불러오는 항목이 없습니다.
  - 날짜별 할 일 목록을 불러올 때, 유저별 모든 할 일 목록을 가져옵니다.
    - 따라서, 날짜별 할 일 목록을 가져오는 메서드를 유저 아이디 별 할 일 목록을 가져오는 메서드로 변경했습니다.